### PR TITLE
Feature: 사용자 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,12 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/sarasa/wantedinternship/controller/MemberController.java
+++ b/src/main/java/sarasa/wantedinternship/controller/MemberController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import sarasa.wantedinternship.domain.entity.Member;
 import sarasa.wantedinternship.dto.SignUpDto;
 import sarasa.wantedinternship.mapper.MemberMapper;
-import sarasa.wantedinternship.repository.MemberRepository;
+import sarasa.wantedinternship.service.MemberService;
 
 import java.net.URI;
 
@@ -20,17 +20,17 @@ import java.net.URI;
 public class MemberController {
 
     private final MemberMapper memberMapper;
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
     @PostMapping("/members")
     public ResponseEntity<?> signUp(@RequestBody @Valid SignUpDto dto) {
         Member member = memberMapper.toEntity(dto);
 
-        Member savedMember = memberRepository.save(member);
+        Long savedMemberId = memberService.signUp(member);
 
         return ResponseEntity.created(
-                URI.create("/members/" + savedMember.getId()))
-                .body(savedMember);
+                URI.create("/members/" + savedMemberId))
+                .build();
     }
 
 }

--- a/src/main/java/sarasa/wantedinternship/controller/MemberController.java
+++ b/src/main/java/sarasa/wantedinternship/controller/MemberController.java
@@ -1,0 +1,36 @@
+package sarasa.wantedinternship.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import sarasa.wantedinternship.domain.entity.Member;
+import sarasa.wantedinternship.dto.SignUpDto;
+import sarasa.wantedinternship.mapper.MemberMapper;
+import sarasa.wantedinternship.repository.MemberRepository;
+
+import java.net.URI;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberMapper memberMapper;
+    private final MemberRepository memberRepository;
+
+    @PostMapping("/members")
+    public ResponseEntity<?> signUp(@RequestBody @Valid SignUpDto dto) {
+        Member member = memberMapper.toEntity(dto);
+
+        Member savedMember = memberRepository.save(member);
+
+        return ResponseEntity.created(
+                URI.create("/members/" + savedMember.getId()))
+                .body(savedMember);
+    }
+
+}

--- a/src/main/java/sarasa/wantedinternship/domain/entity/Member.java
+++ b/src/main/java/sarasa/wantedinternship/domain/entity/Member.java
@@ -1,17 +1,16 @@
 package sarasa.wantedinternship.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Entity
-@Getter
 @ToString
+@Getter @Setter
 @NoArgsConstructor
 public class Member {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     @Column(name = "member_id")
     private Long id;
 

--- a/src/main/java/sarasa/wantedinternship/dto/SignUpDto.java
+++ b/src/main/java/sarasa/wantedinternship/dto/SignUpDto.java
@@ -1,0 +1,10 @@
+package sarasa.wantedinternship.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Size;
+
+public record SignUpDto(
+        @Email String email,
+        @Size(min = 8) String password
+) {
+}

--- a/src/main/java/sarasa/wantedinternship/exception/MemberAlreadyExistsException.java
+++ b/src/main/java/sarasa/wantedinternship/exception/MemberAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package sarasa.wantedinternship.exception;
+
+public class MemberAlreadyExistsException extends RuntimeException {
+
+    public MemberAlreadyExistsException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/sarasa/wantedinternship/mapper/MemberMapper.java
+++ b/src/main/java/sarasa/wantedinternship/mapper/MemberMapper.java
@@ -1,0 +1,12 @@
+package sarasa.wantedinternship.mapper;
+
+import org.mapstruct.Mapper;
+import sarasa.wantedinternship.domain.entity.Member;
+import sarasa.wantedinternship.dto.SignUpDto;
+
+@Mapper(componentModel = "spring")
+public interface MemberMapper {
+
+    Member toEntity(SignUpDto dto);
+
+}

--- a/src/main/java/sarasa/wantedinternship/repository/MemberRepository.java
+++ b/src/main/java/sarasa/wantedinternship/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package sarasa.wantedinternship.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sarasa.wantedinternship.domain.entity.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsByEmail(String email);
+
+}

--- a/src/main/java/sarasa/wantedinternship/service/MemberService.java
+++ b/src/main/java/sarasa/wantedinternship/service/MemberService.java
@@ -1,0 +1,31 @@
+package sarasa.wantedinternship.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sarasa.wantedinternship.domain.entity.Member;
+import sarasa.wantedinternship.exception.MemberAlreadyExistsException;
+import sarasa.wantedinternship.repository.MemberRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Long signUp(Member member) {
+        validateAlreadyExistsMember(member);
+
+        Member savedMember = memberRepository.save(member);
+
+        return savedMember.getId();
+    }
+
+    private void validateAlreadyExistsMember(Member member) {
+        if (memberRepository.existsByEmail(member.getEmail())) {
+            throw new MemberAlreadyExistsException("이미 가입된 회원입니다.");
+        }
+    }
+
+}


### PR DESCRIPTION
1. Feat: MemberRepository 구현
- 기본 CRUD는 JpaRepository 인터페이스를 상속받아 구현
- 이미 회원가입 되어 있는 이메일인지 체크하는 existsByEmail 추가

2. Feat: MemberController 및 필요한 컴포넌트 구현
- build.gradle에 유효성 검증을 위한 validation 및 Dto&Entity 매핑을 위한 mapstruct 추가
- Java 14에서 추가된 record를 활용하여 회원가입 정보 전송용 SignUpDto를 구현
- 매핑을 위한 MemberMapper 추가
- mapstruct가 제대로 매핑을 할 수 있도록 Member에 @Setter 추가 & id는 변한할 수 없도로 NONE 설정
- 아직 MemberService가 없으므로 MemberRepository를 의존성 주입으로 주입받아 DB에 저장되는지 테스트 -> MemberService 구현 후 위임할 예정

3. Feat: MemberService 구현
- 이미 가입된 회원인지 검증하는 비즈니스 로직 추가
- 해당 이메일로 가입된 회원이 이미 존재한다면 RuntimeException을 상속한 커스텀 예외를 던지도록 구현

4. Refactor: API 계층과 Service 계층 연결
- 기존 Repository 의존성 제거 후 Service 계층 의존하도록 변경
- 본문에 회원 전체 정보를 실어서 보내던 부분을 식별자만 헤더로 응답하도록 변경

TODO: 게시글 CRUD 기능 구현 및 Spring Security 적용