### PR TITLE
Feature: 게시글 CRUD 기능 구현

### DIFF
--- a/src/main/java/sarasa/wantedinternship/controller/ArticleController.java
+++ b/src/main/java/sarasa/wantedinternship/controller/ArticleController.java
@@ -1,0 +1,74 @@
+package sarasa.wantedinternship.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import sarasa.wantedinternship.domain.entity.Article;
+import sarasa.wantedinternship.dto.request.ArticleRequestDto;
+import sarasa.wantedinternship.dto.response.ArticleResponseDto;
+import sarasa.wantedinternship.mapper.ArticleMapper;
+import sarasa.wantedinternship.service.ArticleService;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+public class ArticleController {
+
+    private final ArticleMapper articleMapper;
+    private final ArticleService articleService;
+
+    @PostMapping("/articles")
+    public ResponseEntity<?> createArticle(@RequestParam Long memberId,
+                                           @RequestBody ArticleRequestDto dto) {
+        Article article = articleMapper.toEntity(dto);
+
+        Long createdArticleId = articleService.createArticle(memberId, article);
+
+        return ResponseEntity.created(
+                URI.create("/articles/" + createdArticleId))
+                .build();
+    }
+
+    @GetMapping("/articles")
+    public ResponseEntity<?> findArticles(@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<Article> articles = articleService.findArticles(pageable);
+
+        Page<ArticleResponseDto> responses = articles.map(articleMapper::toDto);
+
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/articles/{article-id}")
+    public ResponseEntity<?> findOneArticle(@PathVariable("article-id") Long articleId) {
+        Article article = articleService.findOneArticle(articleId);
+
+        ArticleResponseDto response = articleMapper.toDto(article);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/articles/{article-id}")
+    public ResponseEntity<?> updateArticle(@RequestParam Long memberId,
+                                           @PathVariable("article-id") Long articleId,
+                                           @RequestBody ArticleRequestDto dto) {
+        Article updatedArticle = articleService.updateArticle(memberId, articleId, dto);
+
+        ArticleResponseDto response = articleMapper.toDto(updatedArticle);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/articles/{article-id}")
+    public ResponseEntity<?> deleteArticle(@RequestParam Long memberId,
+                                           @PathVariable("article-id") Long articleId) {
+        articleService.deleteArticle(memberId, articleId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/sarasa/wantedinternship/controller/MemberController.java
+++ b/src/main/java/sarasa/wantedinternship/controller/MemberController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import sarasa.wantedinternship.domain.entity.Member;
-import sarasa.wantedinternship.dto.SignUpDto;
+import sarasa.wantedinternship.dto.request.SignUpDto;
 import sarasa.wantedinternship.mapper.MemberMapper;
 import sarasa.wantedinternship.service.MemberService;
 

--- a/src/main/java/sarasa/wantedinternship/domain/entity/Article.java
+++ b/src/main/java/sarasa/wantedinternship/domain/entity/Article.java
@@ -1,17 +1,16 @@
 package sarasa.wantedinternship.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Entity
-@Getter
+@Getter @Setter
 @ToString
 @NoArgsConstructor
 public class Article {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Setter(AccessLevel.NONE)
     @Column(name = "article_id")
     private Long id;
 
@@ -25,5 +24,9 @@ public class Article {
         this.title = title;
         this.content = content;
     }
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
 }

--- a/src/main/java/sarasa/wantedinternship/dto/ArticleUpdateDto.java
+++ b/src/main/java/sarasa/wantedinternship/dto/ArticleUpdateDto.java
@@ -1,7 +1,0 @@
-package sarasa.wantedinternship.dto;
-
-public record ArticleUpdateDto(
-        String title,
-        String content
-) {
-}

--- a/src/main/java/sarasa/wantedinternship/dto/ArticleUpdateDto.java
+++ b/src/main/java/sarasa/wantedinternship/dto/ArticleUpdateDto.java
@@ -1,0 +1,7 @@
+package sarasa.wantedinternship.dto;
+
+public record ArticleUpdateDto(
+        String title,
+        String content
+) {
+}

--- a/src/main/java/sarasa/wantedinternship/dto/request/ArticleRequestDto.java
+++ b/src/main/java/sarasa/wantedinternship/dto/request/ArticleRequestDto.java
@@ -1,0 +1,7 @@
+package sarasa.wantedinternship.dto.request;
+
+public record ArticleRequestDto(
+        String title,
+        String content
+) {
+}

--- a/src/main/java/sarasa/wantedinternship/dto/request/SignUpDto.java
+++ b/src/main/java/sarasa/wantedinternship/dto/request/SignUpDto.java
@@ -1,4 +1,4 @@
-package sarasa.wantedinternship.dto;
+package sarasa.wantedinternship.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/sarasa/wantedinternship/dto/response/ArticleResponseDto.java
+++ b/src/main/java/sarasa/wantedinternship/dto/response/ArticleResponseDto.java
@@ -1,0 +1,10 @@
+package sarasa.wantedinternship.dto.response;
+
+// todo: 사용자 이름 추가
+
+public record ArticleResponseDto(
+        Long articleId,
+        String title,
+        String content
+) {
+}

--- a/src/main/java/sarasa/wantedinternship/exception/ArticleNotFoundException.java
+++ b/src/main/java/sarasa/wantedinternship/exception/ArticleNotFoundException.java
@@ -1,0 +1,11 @@
+package sarasa.wantedinternship.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+
+public class ArticleNotFoundException extends EntityNotFoundException {
+
+    public ArticleNotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/sarasa/wantedinternship/exception/NoAuthorityException.java
+++ b/src/main/java/sarasa/wantedinternship/exception/NoAuthorityException.java
@@ -1,0 +1,9 @@
+package sarasa.wantedinternship.exception;
+
+public class NoAuthorityException extends RuntimeException {
+
+    public NoAuthorityException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/sarasa/wantedinternship/mapper/ArticleMapper.java
+++ b/src/main/java/sarasa/wantedinternship/mapper/ArticleMapper.java
@@ -1,0 +1,17 @@
+package sarasa.wantedinternship.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import sarasa.wantedinternship.domain.entity.Article;
+import sarasa.wantedinternship.dto.request.ArticleRequestDto;
+import sarasa.wantedinternship.dto.response.ArticleResponseDto;
+
+@Mapper(componentModel = "spring")
+public interface ArticleMapper {
+
+    Article toEntity(ArticleRequestDto dto);
+
+    @Mapping(source = "id", target = "articleId")
+    ArticleResponseDto toDto(Article article);
+
+}

--- a/src/main/java/sarasa/wantedinternship/mapper/MemberMapper.java
+++ b/src/main/java/sarasa/wantedinternship/mapper/MemberMapper.java
@@ -2,7 +2,7 @@ package sarasa.wantedinternship.mapper;
 
 import org.mapstruct.Mapper;
 import sarasa.wantedinternship.domain.entity.Member;
-import sarasa.wantedinternship.dto.SignUpDto;
+import sarasa.wantedinternship.dto.request.SignUpDto;
 
 @Mapper(componentModel = "spring")
 public interface MemberMapper {

--- a/src/main/java/sarasa/wantedinternship/repository/ArticleRepository.java
+++ b/src/main/java/sarasa/wantedinternship/repository/ArticleRepository.java
@@ -1,0 +1,7 @@
+package sarasa.wantedinternship.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sarasa.wantedinternship.domain.entity.Article;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+}

--- a/src/main/java/sarasa/wantedinternship/service/ArticleService.java
+++ b/src/main/java/sarasa/wantedinternship/service/ArticleService.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sarasa.wantedinternship.domain.entity.Article;
-import sarasa.wantedinternship.dto.ArticleUpdateDto;
+import sarasa.wantedinternship.dto.request.ArticleRequestDto;
 import sarasa.wantedinternship.exception.ArticleNotFoundException;
 import sarasa.wantedinternship.exception.NoAuthorityException;
 import sarasa.wantedinternship.repository.ArticleRepository;
@@ -42,10 +42,10 @@ public class ArticleService {
     }
 
     public Article updateArticle(Long memberId, Long articleId,
-                                 ArticleUpdateDto dto) {
+                                 ArticleRequestDto dto) {
         Article article = findOneArticle(articleId);
 
-        validateAuthor(memberId, article);
+        validateMemberIdForUpdateAndDelete(memberId, article);
 
         Optional.ofNullable(dto.title())
                 .ifPresent(article::setTitle);
@@ -58,12 +58,12 @@ public class ArticleService {
     public void deleteArticle(Long memberId, Long articleId) {
         Article article = findOneArticle(articleId);
 
-        validateAuthor(memberId, article);
+        validateMemberIdForUpdateAndDelete(memberId, article);
 
         articleRepository.delete(article);
     }
 
-    private void validateAuthor(Long memberId, Article article) {
+    private void validateMemberIdForUpdateAndDelete(Long memberId, Article article) {
         if (!article.getMember().getId().equals(memberId)) {
             throw new NoAuthorityException("게시글 작성자만 수정 및 삭제가 가능합니다.");
         }

--- a/src/main/java/sarasa/wantedinternship/service/ArticleService.java
+++ b/src/main/java/sarasa/wantedinternship/service/ArticleService.java
@@ -1,0 +1,72 @@
+package sarasa.wantedinternship.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sarasa.wantedinternship.domain.entity.Article;
+import sarasa.wantedinternship.dto.ArticleUpdateDto;
+import sarasa.wantedinternship.exception.ArticleNotFoundException;
+import sarasa.wantedinternship.exception.NoAuthorityException;
+import sarasa.wantedinternship.repository.ArticleRepository;
+import sarasa.wantedinternship.repository.MemberRepository;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+    private final MemberRepository memberRepository;
+
+    public Long createArticle(Long memberId, Article article) {
+        article.setMember(memberRepository.getReferenceById(memberId));
+
+        Article savedArticle = articleRepository.save(article);
+
+        return savedArticle.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Article> findArticles(Pageable pageable) {
+        return articleRepository.findAll(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Article findOneArticle(Long articleId) {
+        return articleRepository.findById(articleId)
+                .orElseThrow(() -> new ArticleNotFoundException("존재하지 않는 게시글입니다."));
+    }
+
+    public Article updateArticle(Long memberId, Long articleId,
+                                 ArticleUpdateDto dto) {
+        Article article = findOneArticle(articleId);
+
+        validateAuthor(memberId, article);
+
+        Optional.ofNullable(dto.title())
+                .ifPresent(article::setTitle);
+        Optional.ofNullable(dto.content())
+                .ifPresent(article::setContent);
+
+        return article;
+    }
+
+    public void deleteArticle(Long memberId, Long articleId) {
+        Article article = findOneArticle(articleId);
+
+        validateAuthor(memberId, article);
+
+        articleRepository.delete(article);
+    }
+
+    private void validateAuthor(Long memberId, Article article) {
+        if (!article.getMember().getId().equals(memberId)) {
+            throw new NoAuthorityException("게시글 작성자만 수정 및 삭제가 가능합니다.");
+        }
+    }
+
+}


### PR DESCRIPTION
1. Feat: ArticleRepository 구현 
- 기본적으로 JpaRepository 상속받아 CRUD 기능 구현
- 서비스 클래스 구현하면서 페이지네이션 코드 추가 예정

2. Refactor: Article & Member 다대일 연관관계 매핑 및 Setter 추가
- id를 제외한 필드에 Setter 추가
- 단방향 다대일 연관관계 매핑 및 지연 로딩 설정

3. Feat: ArticleService CRUD 기능 구현
- 게시글 수정에 사용할 ArticleUpdateDto 추가
- 커스텀 예외 2개 추가
- CRUD 기능 구현 및 수정 및 삭제에 게시글 작성자 권한 방어 로직 추가

4. Rename: dto 패키지 request와 response로 분기
요청과 응답에 사용하는 dto를 나눠서 정리하기로 결정하여 패키지를 분기함

5. Feat: ArticleController 및 필요 컴포넌트 구현 
- 컨트롤러 구현하여 API 계층과 서비스 계층 연결
- 요청, 응답 dto 추가
- mapstruct 사용한 mapper 추가 -> 추후 GenericMapper로 추상화 예정
- 게시글 작성자 검증 메서드 이름 변경

TODO : 초기 테스트 데이터 추가, Mapper 추상화, Spring Security 적용
